### PR TITLE
add: buildMetadata: [originAnnotations] everywhere

### DIFF
--- a/bases/clusters/aws/v1alpha3/kustomization.yaml
+++ b/bases/clusters/aws/v1alpha3/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 kind: Kustomization
 resources:
 - awscluster.yaml

--- a/bases/clusters/capo/<=v0.5.0/kustomization.yaml
+++ b/bases/clusters/capo/<=v0.5.0/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 configMapGenerator:
   - files:
     - values=cluster_config.yaml

--- a/bases/clusters/capo/>=v0.6.0/kustomization.yaml
+++ b/bases/clusters/capo/>=v0.6.0/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 configMapGenerator:
   - files:
     - values=cluster_config.yaml

--- a/bases/clusters/capo/template/kustomization.yaml
+++ b/bases/clusters/capo/template/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 configMapGenerator:
   - files:
     - values=default_apps_config.yaml

--- a/bases/nodepools/aws/v1alpha3/kustomization.yaml
+++ b/bases/nodepools/aws/v1alpha3/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 kind: Kustomization
 resources:
 - awsmachinedeployment.yaml

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -114,6 +114,12 @@ User MAY omit it if they do not relay on the
 and when feeling confident about Flux auto discovering resources. Otherwise it is RECOMMENDED to create it and use it
 to explicitly control resources to be reconciled (with `.bases` and `.resources` fields).
 
+Make sure that if you create the `kustomization.yaml` file, it contains the following option, which makes debugging easier:
+
+```yaml
+buildMetadata: [originAnnotations]
+```
+
 ### `[organizations]`
 
 It is RECOMMENDED to use it explicitly when there are other resources populated under the `MC_NAME` directory, see

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/cluster/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/cluster/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 kind: Kustomization
 patchesStrategicMerge:
 - awscluster.yaml

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 kind: Kustomization
 resources:
 - WC_NAME/WC_NAME.yaml

--- a/management-clusters/MC_NAME/secrets/kustomization.yaml
+++ b/management-clusters/MC_NAME/secrets/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
 kind: Kustomization
 resources:
   - WC_NAME.gpgkey.enc.yaml


### PR DESCRIPTION
Adding this attribute makes `kustomize` include info about the source of the object rendered. Works especially well for remote bases, where it includes info about the remote repo and commit/branch info,