### PR TITLE
add: references to examples in docs

### DIFF
--- a/docs/add_appcr.md
+++ b/docs/add_appcr.md
@@ -2,6 +2,13 @@
 
 Follow the instructions below to add a new App to a cluster managed in this repository.
 
+## Example
+
+Examples of creating apps are available in following locations:
+
+- the simplest use case: an [app without configuration](../management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/apps/hello-world/)
+- an [app that uses a configuration ConfigMap](../management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/apps/nginx-ingress-controller/)
+
 ## Export environment variables
 
 **Note**, Management Cluster codename, Organization name, Workload Cluster name and several App-related values are needed

--- a/docs/add_wc_instance_vintage.md
+++ b/docs/add_wc_instance_vintage.md
@@ -14,6 +14,10 @@ export ORG_NAME=ORGANIZATION
 export WC_NAME=CLUSTER_NAME
 ```
 
+## Example
+
+An example of a WC cluster instance created using the vintage API is available in [WC_NAME/cluster](../management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/cluster/).
+
 ## Pick your Cluster Template
 
 First step needed to create a Cluster instance is to pick a cluster template it will be based on. Templates are available

--- a/docs/add_wc_structure.md
+++ b/docs/add_wc_structure.md
@@ -12,6 +12,10 @@ This includes:
 
 *Note: As always, instructions here respect the [repository structure](./repo_structure.md).*
 
+## Example
+
+An example of a WC cluster directory structure is available in [WC_NAME/](../management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/).
+
 ## Export environment variables
 
 **Note**, Management Cluster codename, Organization name and Workload Cluster name are needed in multiple places across

--- a/docs/add_wc_template_capi.md
+++ b/docs/add_wc_template_capi.md
@@ -24,6 +24,10 @@ in the following manner:
 
 See more about this approach [here](https://github.com/giantswarm/rfc/tree/main/merging-configmaps-gitops).
 
+## Example
+
+An example of a WC cluster template created using the CAPx/CAPI is available in [bases/clusters/capo](../bases/clusters/capo/).
+
 ## Export environment variables
 
 **Note**, Management Cluster codename, Organization name and Workload Cluster name are needed in multiple places

--- a/docs/add_wc_template_vintage.md
+++ b/docs/add_wc_template_vintage.md
@@ -12,6 +12,10 @@ top of them to set specific CAPI versions and version specific properties on top
 
 *Note: As always, instructions here respect the [repository structure](./repo_structure.md).*
 
+## Example
+
+An example of a WC cluster template created using the vintage API is available in [bases/clusters/aws/v1alpha3](../bases/clusters/aws/v1alpha3/).
+
 ## Export environment variables
 
 **Note**, Management Cluster codename, Organization name and Workload Cluster name are needed in multiple places across

--- a/docs/automatic_updates_appcr.md
+++ b/docs/automatic_updates_appcr.md
@@ -19,6 +19,10 @@ will do it by pushing commits to this repository.
 **Note**, in order to use this mechanism you have to make sure that image tags of your App corresponds to its version,
 otherwise this process will result in setting meaningless version in the `.spec.version` field.
 
+## Example
+
+An example of an App automated updates is available in [WC_NAME/apps/web-assets](../management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/apps/web-assets/).
+
 ## Export environment variables
 
 **Note**, Management Cluster codename, Organization name, Workload Cluster name and some App-related values are needed in


### PR DESCRIPTION
We have good examples, but they were not referenced in actual docs. Now, each doc references a code example.