### PR TITLE
Fixing namespaces

### DIFF
--- a/docs/add_wc_structure.md
+++ b/docs/add_wc_structure.md
@@ -187,11 +187,16 @@ to the cluster. Follow the below instructions in order to do it.
     cat <<EOF > kustomization.yaml
     apiVersion: kustomize.config.k8s.io/v1beta1
     kind: Kustomization
-    namespace: ${WC_NAME}
     patches:
     - path: patch_cluster_config.yaml
       target:
         kind: App
+    - patch: |-
+        - op: replace
+          path: "/metadata/namespace"
+          value: ${WC_NAME}
+      target:
+        kind: ".*"
     resources: []
     EOF
     ```

--- a/docs/automatic_updates_appcr.md
+++ b/docs/automatic_updates_appcr.md
@@ -152,7 +152,8 @@ scan for new tags:
     - ${APP_NAME}/imagerepository.yaml
     ```
 
-1. Edit the `kustomization.yaml` file again, and add patch for placing Flux' resources in a default or one of your organization namespaces:
+1. Edit the `kustomization.yaml` file again, and add patch for placing Flux' resources in a default or one of
+your organization namespaces:
 
     ```yaml
     apiVersion: kustomize.config.k8s.io/v1beta1

--- a/docs/automatic_updates_appcr.md
+++ b/docs/automatic_updates_appcr.md
@@ -152,8 +152,8 @@ scan for new tags:
     - ${APP_NAME}/imagerepository.yaml
     ```
 
-1. Edit the `kustomization.yaml` file again, and add patch for placing Flux' resources in a default or one of
-your organization namespaces:
+1. Edit the `kustomization.yaml` file again, and add a patch for placing Flux' resources in the default namespace
+or one of your organization namespaces:
 
     ```yaml
     apiVersion: kustomize.config.k8s.io/v1beta1

--- a/docs/automatic_updates_appcr.md
+++ b/docs/automatic_updates_appcr.md
@@ -147,10 +147,23 @@ scan for new tags:
     ```yaml
     apiVersion: kustomize.config.k8s.io/v1beta1
     kind: Kustomization
-    namespace: default
     resources:
     - ${APP_NAME}/imagepolicy.yaml
     - ${APP_NAME}/imagerepository.yaml
+    ```
+
+1. Edit the `kustomization.yaml` file again, and add patch for placing Flux' resources in a default or one of your organization namespaces:
+
+    ```yaml
+    apiVersion: kustomize.config.k8s.io/v1beta1
+    kind: Kustomization
+    patches:
+    - patch: |-
+      - op: replace
+        path: "/metadata/namespace"
+        value: default
+    target:
+      kind: 'ImagePolicy|ImageRepository'
     ```
 
 ## App CR version field mark


### PR DESCRIPTION
Flux resources must not be created in a cluster namespace, so we must resign from using `namespace` transform for Apps and use patches instead to selectively place Flux CR' into a default or one of org- namespaces.