### PR TITLE
add: capi example

### DIFF
--- a/docs/add_wc_instance_capi.md
+++ b/docs/add_wc_instance_capi.md
@@ -1,11 +1,15 @@
 # Add Workload Cluster instance (CAPx/CAPI)
 
-- [Add Workload Cluster instance (CAPx/CAPI)](#add-workload-cluster-instance-capxcapi)
-  - [Creating cluster based on existing bases](#creating-cluster-based-on-existing-bases)
-  - [Recommended next steps](#recommended-next-steps)
+- [Example](#example)
+- [Creating cluster based on existing bases](#creating-cluster-based-on-existing-bases)
+- [Recommended next steps](#recommended-next-steps)
 
 This doc explains how to create an actual Cluster infrastructure instance. A pre-request for this step is to complete
 [cluster structure](./add_wc_structure.md) preparation step.
+
+## Example
+
+An example of a WC cluster instance created using the CAPI is available in [CAPI_WC_NAME/cluster](/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/cluster/).
 
 ## Creating cluster based on existing bases
 
@@ -18,11 +22,11 @@ This doc explains how to create an actual Cluster infrastructure instance. A pre
 1. If you need to customize cluster configuration, prepare the values overrides and export its path. Find example below:
 
     ```sh
-    cat /tmp/values
+    $ cat /tmp/values
     clusterDescription: My GitOps Cluster
     cloudConfig: my-cloud-config
 
-    export USERCONFIG_VALUES=/tmp/values
+    $ export USERCONFIG_VALUES=/tmp/values
     ```
 
 1. Create a `ConfigMap` out of the values overrides:

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/ORG_NAME.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/ORG_NAME.yaml
@@ -1,6 +1,6 @@
 apiVersion: security.giantswarm.io/v1alpha1
 kind: Organization
 metadata:
-  name: "${organization}"
+  name: ORG_NAME
 spec: {}
 status: {}

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: clusters-CAPI_WC_NAME
+  namespace: default
+spec:
+  interval: 1m
+  path: "./management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME"
+  postBuild:
+    substitute:
+      cluster_domain: "MY_DOMAIN"
+      cluster_name: "CAPI_WC_NAME"
+      cluster_release: "0.8.1"
+      default_apps_release: "0.2.0"
+      organization: "ORG_NAME"
+  prune: false
+  serviceAccountName: automation
+  sourceRef:
+    kind: GitRepository
+    name: REPO_NAME
+  timeout: 2m

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/apps/cert-manager/appcr.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/apps/cert-manager/appcr.yaml
@@ -1,0 +1,9 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: cert-manager
+spec:
+  catalog: giantswarm
+  name: cert-manager-app
+  namespace: kube-system
+  version: 2.12.0

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/apps/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/apps/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  giantswarm.io/cluster: CAPI_WC_NAME
+  giantswarm.io/managed-by: flux
+kind: Kustomization
+namespace: org-${organization}
+patches:
+  - path: patch_cluster_config.yaml
+    target:
+      kind: App
+resources:
+  - cert-manager/appcr.yaml

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/apps/patch_cluster_config.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/apps/patch_cluster_config.yaml
@@ -1,0 +1,14 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  labels:
+    giantswarm.io/managed-by: flux
+  name: ignored
+spec:
+  kubeConfig:
+    context:
+      name: ${cluster_name}-admin@${cluster_name}
+    inCluster: false
+    secret:
+      name: ${cluster_name}-kubeconfig
+      namespace: org-${organization}

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/cluster/cluster_userconfig.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/cluster/cluster_userconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  values: |
+    cloudConfig: cloud-config-giantswarm-2
+    cloudName: openstack
+    externalNetworkID: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+kind: ConfigMap
+metadata:
+  name: ${cluster_name}-userconfig
+  namespace: org-${organization}

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/cluster/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/cluster/kustomization.yaml
@@ -4,7 +4,7 @@ commonLabels:
   giantswarm.io/managed-by: flux
 kind: Kustomization
 patchesStrategicMerge:
-- patch_awscluster.yaml
+  - patch_userconfig.yaml
 resources:
-- ../../../../../../../bases/clusters/aws/v1alpha3
-#- ../../../../../../../bases/nodepools/aws/v1alpha3
+- ../../../../../../../bases/clusters/capo/>=v0.6.0
+- cluster_userconfig.yaml

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/cluster/patch_userconfig.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/CAPI_WC_NAME/cluster/patch_userconfig.yaml
@@ -1,0 +1,10 @@
+apiVersion: application.giantswarm.io/v1alpha1
+kind: App
+metadata:
+  name: ${cluster_name}
+  namespace: org-${organization}
+spec:
+  userConfig:
+    configMap:
+      name: ${cluster_name}-userconfig
+      namespace: org-${organization}

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
-  name: ${workload_cluster_name}
+  name: clusters-WC_NAME
   namespace: default
 spec:
   decryption:
@@ -21,5 +21,5 @@ spec:
   serviceAccountName: automation
   sourceRef:
     kind: GitRepository
-    name: ${gitops_repo}
+    name: REPO_NAME
   timeout: 2m

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/app_sets/hello-web-app-1/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/app_sets/hello-web-app-1/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 buildMetadata: [originAnnotations]
+commonLabels:
+  giantswarm.io/managed-by: flux
 configMapGenerator:
   - files:
       - values=override_config_hello_world.yaml

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/apps/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/apps/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+buildMetadata: [originAnnotations]
+commonLabels:
+  giantswarm.io/managed-by: flux
+kind: Kustomization
+resources:
+- hello-world/appcr.yaml
+- hello-world-automatic-updates/appcr.yaml
+- hello-world-automatic-updates/imagepolicy.yaml
+- hello-world-automatic-updates/imagerepository.yaml
+- nginx-from-template/
+- nginx-ingress-controller/appcr.yaml
+- nginx-ingress-controller/configmap.yaml

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/automatic-updates/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME/automatic-updates/kustomization.yaml
@@ -3,8 +3,6 @@ buildMetadata: [originAnnotations]
 commonLabels:
   giantswarm.io/managed-by: flux
 kind: Kustomization
-patchesStrategicMerge:
-- patch_awscluster.yaml
 resources:
-- ../../../../../../../bases/clusters/aws/v1alpha3
-#- ../../../../../../../bases/nodepools/aws/v1alpha3
+- catalog.yaml
+- imageupdate.yaml

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 buildMetadata: [originAnnotations]
 kind: Kustomization
 resources:
+- CAPI_WC_NAME.yaml
 - WC_NAME.yaml

--- a/management-clusters/MC_NAME/secrets/kustomization.yaml
+++ b/management-clusters/MC_NAME/secrets/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 buildMetadata: [originAnnotations]
 kind: Kustomization
 resources:
+  - MC_NAME.gpgkey.enc.yaml
   - WC_NAME.gpgkey.enc.yaml


### PR DESCRIPTION
- adds a CAPI example cluster
- fixes some bugs
  - mostly missing `managed-by: flux` labels
  - some bad usage of variable substitution