### PR TITLE
fix: reformat all command listings

### DIFF
--- a/docs/add_mc.md
+++ b/docs/add_mc.md
@@ -1,11 +1,10 @@
 # Add a new Management Cluster
 
-- [Add a new Management Cluster](#add-a-new-management-cluster)
-  - [Export Management Cluster codename](#export-management-cluster-codename)
-  - [Flux GPG master key pair](#flux-gpg-master-key-pair)
-  - [Directory tree](#directory-tree)
-  - [Initial cluster configuration](#initial-cluster-configuration)
-  - [Recommended next steps](#recommended-next-steps)
+- [Export Management Cluster codename](#export-management-cluster-codename)
+- [Flux GPG master key pair](#flux-gpg-master-key-pair)
+- [Directory tree](#directory-tree)
+- [Initial cluster configuration](#initial-cluster-configuration)
+- [Recommended next steps](#recommended-next-steps)
 
 Follow the instructions below to add a new management cluster to this repository. You need to have a valid connection
 (`kube.config`) to the Management Cluster. The instructions respect the [repository structure](./repo_structure.md).
@@ -60,10 +59,18 @@ en- and decrypt real user-related data.
 
     ```sh
     gpg --list-secret-keys "${KEY_NAME}"
+    ```
 
+    The command above should produce the output like:
+
+    ```text
     sec   rsa4096 2021-11-25 [SC]
           XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    ```
 
+    Now, export the fingerprint:
+
+    ```sh
     export KEY_FP=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     ```
 

--- a/docs/add_org.md
+++ b/docs/add_org.md
@@ -1,10 +1,9 @@
 # Add a new Organization
 
-- [Add a new Organization](#add-a-new-organization)
-  - [Export environment variables](#export-environment-variables)
-  - [Directory tree](#directory-tree)
-  - [Create a regular GPG key pair for encrypting Organization' secrets (optional step)](#create-a-regular-gpg-key-pair-for-encrypting-organization-secrets-optional-step)
-  - [Recommended next steps](#recommended-next-steps)
+- [Export environment variables](#export-environment-variables)
+- [Directory tree](#directory-tree)
+- [Create a regular GPG key pair for encrypting Organization' secrets (optional step)](#create-a-regular-gpg-key-pair-for-encrypting-organization-secrets-optional-step)
+- [Recommended next steps](#recommended-next-steps)
 
 Follow the below instructions to add a new Organization to this repository. Organizations are created within the
 [Management Cluster's configuration](./add_mc.md) directory and in turn are meant to include
@@ -106,11 +105,19 @@ new GPG key-pair dedicated for an organization.
 
     ```sh
     gpg --list-secret-keys "${KEY_NAME}"
+    ```
 
+    The command above should produce the output like:
+
+    ```text
     sec   rsa4096 2021-11-25 [SC]
-          YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+          XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    ```
 
-    export KEY_FP=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+    Now, export the fingerprint:
+
+    ```sh
+    export KEY_FP=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     ```
 
 1. Share the new GPG public key in this repository:

--- a/docs/add_wc_instance_capi.md
+++ b/docs/add_wc_instance_capi.md
@@ -21,12 +21,16 @@ An example of a WC cluster instance created using the CAPI is available in [CAPI
 
 1. If you need to customize cluster configuration, prepare the values overrides and export its path. Find example below:
 
-    ```sh
-    $ cat /tmp/values
+    ```yaml
+    # cat /tmp/values
     clusterDescription: My GitOps Cluster
     cloudConfig: my-cloud-config
+    ```
 
-    $ export USERCONFIG_VALUES=/tmp/values
+    Export the path to the file:
+
+    ```sh
+    export USERCONFIG_VALUES=/tmp/values
     ```
 
 1. Create a `ConfigMap` out of the values overrides:

--- a/docs/add_wc_instance_vintage.md
+++ b/docs/add_wc_instance_vintage.md
@@ -1,11 +1,10 @@
 # Add Workload Cluster instance (vintage)
 
-- [Add Workload Cluster instance (vintage)](#add-workload-cluster-instance-vintage)
-  - [Export environment variables](#export-environment-variables)
-  - [Example](#example)
-  - [Pick your Cluster Template](#pick-your-cluster-template)
-  - [Creating cluster based on vintage cluster template](#creating-cluster-based-on-vintage-cluster-template)
-  - [Recommended next steps](#recommended-next-steps)
+- [Export environment variables](#export-environment-variables)
+- [Example](#example)
+- [Pick your Cluster Template](#pick-your-cluster-template)
+- [Creating cluster based on vintage cluster template](#creating-cluster-based-on-vintage-cluster-template)
+- [Recommended next steps](#recommended-next-steps)
 
 This doc explains how to create an actual Cluster infrastructure instance. A pre-request for this step is to complete
 [cluster structure](./add_wc_structure.md) preparation step.
@@ -67,7 +66,7 @@ as Kustomize bases in the [bases](/bases/) directory. There's also
 1. Edit the Kustomization CR for the workload cluster and assign values to the variables from bases, see example below:
 
     ```yaml
-    # ${WC_NAME}.yaml
+    # cat ${WC_NAME}.yaml
     apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
     kind: Kustomization
     ...

--- a/docs/add_wc_structure.md
+++ b/docs/add_wc_structure.md
@@ -1,12 +1,11 @@
 # Add a new Workload Cluster repository structure
 
-- [Add a new Workload Cluster repository structure](#add-a-new-workload-cluster-repository-structure)
-  - [Example](#example)
-  - [Export environment variables](#export-environment-variables)
-  - [Create Flux GPG regular key pair (optional step)](#create-flux-gpg-regular-key-pair-optional-step)
-  - [Directory tree](#directory-tree)
-  - [MC configuration](#mc-configuration)
-  - [Recommended next steps](#recommended-next-steps)
+- [Example](#example)
+- [Export environment variables](#export-environment-variables)
+- [Create Flux GPG regular key pair (optional step)](#create-flux-gpg-regular-key-pair-optional-step)
+- [Directory tree](#directory-tree)
+- [MC configuration](#mc-configuration)
+- [Recommended next steps](#recommended-next-steps)
 
 Adding a new Workload Cluster requires a few major steps in the configuration process. One of them
 is to prepare the necessary structure and configuration for the GitOps repository itself.
@@ -68,11 +67,19 @@ Kubernetes Secret, you MUST not create multiple Secrets.
 
     ```sh
     gpg --list-secret-keys "${KEY_NAME}"
+    ```
 
+    The command above should produce the output like:
+
+    ```text
     sec   rsa4096 2021-11-25 [SC]
-          YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+          XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    ```
 
-    export KEY_FP=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY
+    Now, export the fingerprint:
+
+    ```sh
+    export KEY_FP=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     ```
 
 1. Save the private key as a Kubernetes Secret into the MC `secrets` directory:


### PR DESCRIPTION
reformat all command listings to make them easy to copy-paste