### PR TITLE
Replace kubeval with kubeconform

### DIFF
--- a/.github/workflows/diff-preview.yaml
+++ b/.github/workflows/diff-preview.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       dyff_ver: 1.5.4
-      kubeval_ver: 0.16.1
+      kubeconform_ver: 0.4.13
     steps:
       - run: sudo apt-get install -y yamllint
       - name: install dyff
@@ -24,12 +24,12 @@ jobs:
       - run: which dyff
       - uses: giantswarm/install-binary-action@v1
         with:
-          binary: kubeval
-          download_url: "https://github.com/instrumenta/kubeval/releases/download/v${version}/kubeval-linux-amd64.tar.gz"
-          smoke_test: "${binary} --version"
+          binary: kubeconform
+          download_url: "https://github.com/yannh/kubeconform/releases/download/v${version}/kubeconform-linux-amd64.tar.gz"
+          smoke_test: "${binary} -v"
           tarball_binary_path: "${binary}"
-          version: ${{ env.kubeval_ver }}
-      - run: which kubeval
+          version: ${{ env.kubeconform_ver }}
+      - run: which kubeconform
       - run: ls -la /opt/hostedtoolcache
       - uses: actions/checkout@v3
       - name: template all for the new branch

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,16 +22,16 @@ jobs:
     needs: pre-commit
     runs-on: ubuntu-latest
     env:
-      kubeval_ver: 0.16.1
+      kubeconform_ver: 0.4.13
     steps:
       - run: sudo apt-get install -y yamllint
       - uses: giantswarm/install-binary-action@v1
         with:
-          binary: kubeval
-          download_url: "https://github.com/instrumenta/kubeval/releases/download/v${version}/kubeval-linux-amd64.tar.gz"
-          smoke_test: "${binary} --version"
+          binary: kubeconform
+          download_url: "https://github.com/yannh/kubeconform/releases/download/v${version}/kubeconform-linux-amd64.tar.gz"
+          smoke_test: "${binary} -v"
           tarball_binary_path: "${binary}"
-          version: ${{ env.kubeval_ver }}
+          version: ${{ env.kubeconform_ver }}
       - name: cache validation tools
         uses: actions/cache@v3
         with:

--- a/docs/appendices.md
+++ b/docs/appendices.md
@@ -16,3 +16,10 @@ For core utilties like `base64`, `sed`, `tr`, etc. GNU compatible versions are a
 ### Working with YAML files
 
 For `yq` the [github.com/mikefarah/yq](https://github.com/mikefarah/yq/) version is assumed in the code examples.
+
+### Validating yaml files in the repository
+
+You need the following tools installed to use [test-all-ffb](/tools/test-all-ffb) script.
+
+- `yamllint` of [github.com/adrienverge/yamllint](https://github.com/adrienverge/yamllint)
+- `kubeconform` of [github.com/yannh/kubeconform](https://github.com/yannh/kubeconform)

--- a/tools/test-all-ffb
+++ b/tools/test-all-ffb
@@ -39,8 +39,8 @@ test() {
 						echo "Testing: $mc_name $org_name $wc_name $dir_name"
 						echo -n "yamllint: "
 						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | yamllint - && echo "OK"
-						echo "kubeval: "
-						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | kubeval --ignore-missing-schemas
+						echo "kubeconform: "
+						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | kubeconform -ignore-missing-schemas -output text | sed s/stdin\ -\ //g
 						echo ""
 					else
 						echo "---"

--- a/tools/test-all-ffb
+++ b/tools/test-all-ffb
@@ -40,7 +40,7 @@ test() {
 						echo -n "yamllint: "
 						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | yamllint - && echo "OK"
 						echo "kubeconform: "
-						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | kubeconform -ignore-missing-schemas -output text | sed s/stdin\ -\ //g
+						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | kubeconform -ignore-missing-schemas -output text && echo "OK"
 						echo ""
 					else
 						echo "---"


### PR DESCRIPTION
The `kubeval` tool does not seem to be maintained anymore. The backend behind `kubeval` was forked to https://github.com/yannh/kubernetes-json-schema and [kubeconform](https://github.com/yannh/kubeconform) is the new, improved CLI in front of it.