### PR TITLE
Validate CR schemas with kubeconform

### DIFF
--- a/tools/test-all-ffb
+++ b/tools/test-all-ffb
@@ -14,6 +14,11 @@ Usage: $0 [validate|template]
 	exit 1
 }
 
+GS_SCHEMA_REPOSITORY="https://raw.githubusercontent.com/giantswarm/json-schema/main/master"
+GS_SCHEMA_REPOSITORY_CACHE="/tmp/gs-schema-repository-cache"
+
+mkdir -p "${GS_SCHEMA_REPOSITORY_CACHE}"
+
 test() {
 	mode="$1"
 	mc_dir="management-clusters"
@@ -40,7 +45,8 @@ test() {
 						echo -n "yamllint: "
 						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | yamllint - && echo "OK"
 						echo -n "kubeconform: "
-						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | kubeconform -ignore-missing-schemas -output text && echo "OK"
+						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" |
+							kubeconform -ignore-missing-schemas -schema-location "${GS_SCHEMA_REPOSITORY}/{{ .ResourceKind }}{{ .KindSuffix }}.json" -cache "${GS_SCHEMA_REPOSITORY_CACHE}" -output text && echo "OK"
 						echo ""
 					else
 						echo "---"

--- a/tools/test-all-ffb
+++ b/tools/test-all-ffb
@@ -14,9 +14,12 @@ Usage: $0 [validate|template]
 	exit 1
 }
 
-GS_SCHEMA_REPOSITORY="https://raw.githubusercontent.com/giantswarm/json-schema/main/master"
-GS_SCHEMA_REPOSITORY_CACHE="/tmp/gs-schema-repository-cache"
+KUBERNETES_VERSION="master"
 
+KUBERNETES_SCHEMA_REPOSITORY="https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/${KUBERNETES_VERSION}/"
+GS_SCHEMA_REPOSITORY="https://raw.githubusercontent.com/giantswarm/json-schema/main/master"
+
+GS_SCHEMA_REPOSITORY_CACHE="/tmp/gs-schema-repository-cache"
 mkdir -p "${GS_SCHEMA_REPOSITORY_CACHE}"
 
 test() {
@@ -46,7 +49,7 @@ test() {
 						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" | yamllint - && echo "OK"
 						echo -n "kubeconform: "
 						./tools/fake-flux-build build "$mc_name" "$org_name" "$wc_name" "$dir_name" |
-							kubeconform -ignore-missing-schemas -schema-location "${GS_SCHEMA_REPOSITORY}/{{ .ResourceKind }}{{ .KindSuffix }}.json" -cache "${GS_SCHEMA_REPOSITORY_CACHE}" -output text && echo "OK"
+							kubeconform -ignore-missing-schemas -schema-location="${KUBERNETES_SCHEMA_REPOSITORY}/{{ .ResourceKind }}{{ .KindSuffix }}.json" -schema-location "${GS_SCHEMA_REPOSITORY}/{{ .ResourceKind }}{{ .KindSuffix }}.json" -cache "${GS_SCHEMA_REPOSITORY_CACHE}" -output text && echo "OK"
 						echo ""
 					else
 						echo "---"


### PR DESCRIPTION
The validation is done via:
- https://github.com/yannh/kubernetes-json-schema (master folder, but potentially we can select kubernetes version as well)
- https://github.com/giantswarm/json-schema (a sync of schemas for commonly used CRDs in Giant Swarm clusters)