### PR TITLE
Revert "change action to one supporting columns"

### DIFF
--- a/.github/workflows/add-to-hb-board.yaml
+++ b/.github/workflows/add-to-hb-board.yaml
@@ -6,17 +6,13 @@ on:
   pull_request:
     types: [opened]
 
-env:
-  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
-
 jobs:
-  assign_one_project:
+  add-to-project:
+    name: Add issue to project
     runs-on: ubuntu-latest
-    name: Assign to honeybadger project
     steps:
-    - name: Assign NEW issues and NEW pull requests to project
-      uses: srggrs/assign-one-project-github-action@1.2.1
-      if: github.event.action == 'opened'
-      with:
-        project: 'https://github.com/orgs/giantswarm/projects/320'
-        column_name: 'Inbox'
+      - uses: actions/add-to-project@v0.3.0
+        if: github.event.action == 'opened'
+        with:
+          project-url: https://github.com/orgs/giantswarm/projects/320
+          github-token: ${{ secrets.MY_GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts giantswarm/gitops-template#75

This action is even more shitty than the previous one.