### PR TITLE
Migrating to extraConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - migrated `.spec.config` to `.spec.extraConfigs`
+
 ## [0.1.0] Initial release
 
 - Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- migrated `.spec.config` to `.spec.extraConfigs`
 ## [0.1.0] Initial release
 
 - Added

--- a/bases/apps/hello-world/appcr.yaml
+++ b/bases/apps/hello-world/appcr.yaml
@@ -5,10 +5,11 @@ metadata:
   namespace: org-${organization}
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: ${cluster_name}-hello-world-values
       namespace: org-${organization}
+      priority: 1
   kubeConfig:
     inCluster: false
   name: hello-world-app

--- a/bases/apps/nginx-ingress-controller/appcr.yaml
+++ b/bases/apps/nginx-ingress-controller/appcr.yaml
@@ -2,13 +2,14 @@ apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
   name: ${cluster_name}-nginx-ingress-controller
-  namespace: kube-system
+  namespace: org-${organization}
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: ${cluster_name}-nginx-ingress-controller-values
-      namespace: kube-system
+      namespace: org-${organization}
+      priority: 1
   kubeConfig:
     inCluster: false
   name: nginx-ingress-controller-app

--- a/bases/apps/nginx-ingress-controller/appcr.yaml
+++ b/bases/apps/nginx-ingress-controller/appcr.yaml
@@ -2,13 +2,13 @@ apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
   name: ${cluster_name}-nginx-ingress-controller
-  namespace: org-${organization}
+  namespace: kube-system
 spec:
   catalog: giantswarm
   extraConfigs:
     - kind: configMap
       name: ${cluster_name}-nginx-ingress-controller-values
-      namespace: org-${organization}
+      namespace: kube-system
       priority: 1
   kubeConfig:
     inCluster: false

--- a/bases/apps/simple-db/appcr.yaml
+++ b/bases/apps/simple-db/appcr.yaml
@@ -5,10 +5,11 @@ metadata:
   namespace: org-${organization}
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: ${cluster_name}-simple-db-values
       namespace: org-${organization}
+      priority: 1
   kubeConfig:
     inCluster: false
   name: simple-db-app

--- a/bases/clusters/capo/>=v0.6.0/patch_config.yaml
+++ b/bases/clusters/capo/>=v0.6.0/patch_config.yaml
@@ -4,7 +4,8 @@ metadata:
   name: ${cluster_name}
   namespace: org-${organization}
 spec:
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: ${cluster_name}-config
       namespace: org-${organization}
+      priority: 1

--- a/bases/clusters/capo/template/default_apps.yaml
+++ b/bases/clusters/capo/template/default_apps.yaml
@@ -7,10 +7,11 @@ metadata:
   namespace: org-${organization}
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: ${cluster_name}-default-apps-config
       namespace: org-${organization}
+      priority: 1
   kubeConfig:
     inCluster: true
   name: default-apps-openstack

--- a/docs/add_wc_environments.md
+++ b/docs/add_wc_environments.md
@@ -53,12 +53,6 @@ Once your environment templates are ready, you can use them to create new cluste
 in [/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters](
 /management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters)
 
-> :construction: Please note that if you want to use multiple environment templates to create a single cluster
-that uses `App CR`s for deployments, like you would like to use `dev` out of `staging` layout to set app configuration
-and then use `east` from the `data-centers` to set the IP ranges, you will run into issues around merging
-configurations, as currently one configuration source (i.e. `ConfigMap` in `spec.config.configMap`) completely
-overrides the whole value of the same attribute coming from the other base. We're working to remove this limitation.
-
 ### Stages
 
 We have 3 example clusters under [/bases/environments/stages](/bases/environments/stages):

--- a/docs/add_wc_template.md
+++ b/docs/add_wc_template.md
@@ -118,10 +118,11 @@ as this can strongly depend on resources involved, how much of them you would li
       namespace: org-\${organization}
     spec:
       catalog: giantswarm
-      config:
-        configMap:
+      extraConfig
+        - kind: configMap
           name: \${cluster_name}-default-apps-config
           namespace: org-\${organization}
+          priority: 1
       kubeConfig:
         inCluster: true
       name: default-apps-${PROVIDER}
@@ -284,10 +285,11 @@ pools, etc.:
       name: \${cluster_name}
       namespace: org-\${organization}
     spec:
-      config:
-        configMap:
+      extraConfigs:
+        - kind: configMap
           name: \${cluster_name}-config
           namespace: org-\${organization}
+          priority: 1
     EOF
     ```
 

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/HELLO_APP_PROD_CLUSTER_EU_CENTRAL/mapi/cluster/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/HELLO_APP_PROD_CLUSTER_EU_CENTRAL/mapi/cluster/kustomization.yaml
@@ -4,10 +4,10 @@ kind: Kustomization
 patches:
   - patch: |
       - op: add
-        path: /spec/extraConfigs
+        path: /spec/extraConfigs/-
         value:
           # See: https://docs.giantswarm.io/app-platform/app-configuration/#extra-configs
-          - name: "${cluster_name}-region-config"
+            name: "${cluster_name}-region-config"
             namespace: org-${organization}
     target:
       group: application.giantswarm.io

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/HELLO_APP_PROD_CLUSTER_US_WEST/mapi/cluster/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/HELLO_APP_PROD_CLUSTER_US_WEST/mapi/cluster/kustomization.yaml
@@ -4,10 +4,10 @@ kind: Kustomization
 patches:
   - patch: |
       - op: add
-        path: /spec/extraConfigs
+        path: /spec/extraConfigs/-
         value:
           # See: https://docs.giantswarm.io/app-platform/app-configuration/#extra-configs
-          - name: "${cluster_name}-region-config"
+            name: "${cluster_name}-region-config"
             namespace: org-${organization}
     target:
       group: application.giantswarm.io

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/nginx-from-template/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/nginx-from-template/kustomization.yaml
@@ -13,6 +13,16 @@ namespace: kube-system
 patches:
   - patch: |-
       - op: replace
+        path: "/spec/extraConfigs/0/name"
+        value: ${cluster_name}-tmpl-nginx-ingress-controller-values
+    target:
+      group: application.giantswarm.io
+      kind: "App"
+      name: \${cluster_name}-nginx-ingress-controller
+      namespace: kube-system
+      version: v1alpha1
+  - patch: |-
+      - op: replace
         path: "/metadata/name"
         value: ${cluster_name}-tmpl-nginx-ingress-controller
     target:

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/nginx-from-template/patch_app_config.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/nginx-from-template/patch_app_config.yaml
@@ -4,9 +4,6 @@ metadata:
   name: ${cluster_name}-nginx-ingress-controller
   namespace: kube-system
 spec:
-  config:
-    configMap:
-      name: ${cluster_name}-tmpl-nginx-ingress-controller-values
   userConfig:
     configMap:
       name: ${cluster_name}-tmpl-nginx-ingress-controller-user-values

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/apps/nginx-from-template/kustomization.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/apps/nginx-from-template/kustomization.yaml
@@ -13,6 +13,16 @@ namespace: kube-system
 patches:
   - patch: |-
       - op: replace
+        path: "/spec/extraConfigs/0/name"
+        value: ${cluster_name}-tmpl-nginx-ingress-controller-values
+    target:
+      group: application.giantswarm.io
+      kind: "App"
+      name: \${cluster_name}-nginx-ingress-controller
+      namespace: kube-system
+      version: v1alpha1
+  - patch: |-
+      - op: replace
         path: "/metadata/name"
         value: ${cluster_name}-tmpl-nginx-ingress-controller
     target:

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/apps/nginx-from-template/patch_app_config.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/apps/nginx-from-template/patch_app_config.yaml
@@ -4,9 +4,6 @@ metadata:
   name: ${cluster_name}-nginx-ingress-controller
   namespace: kube-system
 spec:
-  config:
-    configMap:
-      name: ${cluster_name}-tmpl-nginx-ingress-controller-values
   userConfig:
     configMap:
       name: ${cluster_name}-tmpl-nginx-ingress-controller-user-values

--- a/tests/ats/assertions/exists/organizations/workload-clusters/capi-wc-name/app_capi-wc-name-default-apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/capi-wc-name/app_capi-wc-name-default-apps.yaml
@@ -5,10 +5,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: capi-wc-name-default-apps-config
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: true
   name: default-apps-openstack

--- a/tests/ats/assertions/exists/organizations/workload-clusters/capi-wc-name/app_capi-wc-name.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/capi-wc-name/app_capi-wc-name.yaml
@@ -5,10 +5,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: capi-wc-name-config
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: true
   name: cluster-openstack

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/apps.yaml
@@ -11,7 +11,7 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  extraConfig:
+  extraConfigs:
     - kind: configMap
       name: hello-app-dev-1-config
       namespace: org-org-name
@@ -38,7 +38,7 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  extraConfig:
+  extraConfigs:
     - kind: configMap
       name: hello-app-dev-1-default-apps-config
       namespace: org-org-name
@@ -60,7 +60,7 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  extraConfig:
+  extraConfigs:
     - kind: configMap
       name: hello-app-dev-1-hello-world-values
       namespace: org-org-name
@@ -82,7 +82,7 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  extraConfig:
+  extraConfigs:
     - kind: configMap
       name: hello-app-dev-1-simple-db-values
       namespace: org-org-name

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/apps.yaml
@@ -11,10 +11,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfig:
+    - kind: configMap
       name: hello-app-dev-1-config
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: true
   name: cluster-openstack
@@ -37,10 +38,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfig:
+    - kind: configMap
       name: hello-app-dev-1-default-apps-config
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: true
   name: default-apps-openstack
@@ -58,10 +60,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfig:
+    - kind: configMap
       name: hello-app-dev-1-hello-world-values
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: false
   name: hello-world-app
@@ -79,10 +82,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfig:
+    - kind: configMap
       name: hello-app-dev-1-simple-db-values
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: false
   name: simple-db-app

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-prod-eu-central/apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-prod-eu-central/apps.yaml
@@ -11,11 +11,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: hello-app-prod-eu-central-config
       namespace: org-org-name
-  extraConfigs:
+      priority: 1
     - name: hello-app-prod-eu-central-region-config
       namespace: org-org-name
   kubeConfig:
@@ -40,10 +40,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: hello-app-prod-eu-central-default-apps-config
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: true
   name: default-apps-openstack
@@ -61,10 +62,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: hello-app-prod-eu-central-hello-world-values
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: false
   name: hello-world-app
@@ -82,10 +84,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMap
       name: hello-app-prod-eu-central-simple-db-values
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: false
   name: simple-db-app

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
@@ -11,10 +11,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfigs:
+    - kind: configMaps:
       name: hello-app-staging-1-config
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: true
   name: cluster-openstack
@@ -37,10 +38,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfig:
+    - kind: configMap
       name: hello-app-staging-1-default-apps-config
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: true
   name: default-apps-openstack
@@ -58,10 +60,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfig:
+    - kind: configMap
       name: hello-app-staging-1-hello-world-values
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: false
   name: hello-world-app
@@ -79,10 +82,11 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  config:
-    configMap:
+  extraConfig:
+    - kind: configMap
       name: hello-app-staging-1-simple-db-values
       namespace: org-org-name
+      priority: 1
   kubeConfig:
     inCluster: false
   name: simple-db-app

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   catalog: giantswarm
   extraConfigs:
-    - kind: configMaps:
+    - kind: configMaps
       name: hello-app-staging-1-config
       namespace: org-org-name
       priority: 1

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   catalog: giantswarm
   extraConfigs:
-    - kind: configMaps
+    - kind: configMap
       name: hello-app-staging-1-config
       namespace: org-org-name
       priority: 1

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/apps.yaml
@@ -38,7 +38,7 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  extraConfig:
+  extraConfigs:
     - kind: configMap
       name: hello-app-staging-1-default-apps-config
       namespace: org-org-name
@@ -60,7 +60,7 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  extraConfig:
+  extraConfigs:
     - kind: configMap
       name: hello-app-staging-1-hello-world-values
       namespace: org-org-name
@@ -82,7 +82,7 @@ metadata:
   namespace: org-org-name
 spec:
   catalog: giantswarm
-  extraConfig:
+  extraConfigs:
     - kind: configMap
       name: hello-app-staging-1-simple-db-values
       namespace: org-org-name


### PR DESCRIPTION
## Description

Towards: https://github.com/giantswarm/giantswarm/issues/24801

This PR generally migrates away from using the `.spec.config` towards using the `.spec.extraConfigs` field for App CRs coming from bases. For those App CRs, what was previously configured under the config field is now the part of the extra configs array with priority 1. 

About the priority itself, it does not necessarily need be the 1, actually I'm struggling to find the right one myself. It is because, I think, choosing the right priority may depend on the context. For example, if I am to provide base configuration that should be later patched by the cluster specific configuration, aka `CLUSTER-cluster-values` referenced by `.spec.config`, then using priority 1 seems as a good choice, as it is the lowest possible one. But using the default one of 25 also satisfies the requirement, but `1` feels like a stronger way of saying this is a base configuration, and other layers may override it.

## Changelog

- [x] Update changelog in CHANGELOG.md.