### PR TITLE
Minor changes to fake-flux-build

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -36,6 +36,17 @@ fake-flux-build build gollum giantswarm c68pn apps/docs
 fake-flux-build build gamma multi-project flux01 /
 ```
 
+#### Using `fake-flux-build` to show a single resource set
+
+You can use a combination of `fake-flux-build` and `yq` to show specific resources under a given path which can be
+useful for troubleshooting issues with that resources deployment.
+
+This is achieved by using `yq` selectors to match the reource(s) in question
+
+```bash
+fake-flux-build build gorilla giantswarm-production rfjh2 / | yq 'select(.kind == "App" and .metadata.name == "ailefroide*")'
+```
+
 ## Test All FFB
 
 You can use this bash tool under a repository based on this template to get verify the syntax of your manifests.

--- a/tools/fake-flux-build
+++ b/tools/fake-flux-build
@@ -106,7 +106,7 @@ EOF
 findres() {
 	if ! [ -e "$1"/kustomization.yaml ]; then
 		for f in $(find "$1" -maxdepth 1 -type f -name "*.yaml" | sed "s|$2/*||g"); do
-			resources+=("$(tr -s '/' <<< $f)")
+			resources+=("$(tr -s '/' <<<$f)")
 		done
 
 		for d in $(find "$1" -maxdepth 1 -type d ! -path "$1"); do
@@ -114,7 +114,7 @@ findres() {
 		done
 	else
 		r=$(echo "$1" | sed "s|$2/*||g")
-		resources+=("$(tr -s '/' <<< $r)")
+		resources+=("$(tr -s '/' <<<$r)")
 	fi
 }
 

--- a/tools/fake-flux-build
+++ b/tools/fake-flux-build
@@ -106,6 +106,7 @@ EOF
 findres() {
 	if ! [ -e "$1"/kustomization.yaml ]; then
 		for f in $(find "$1" -maxdepth 1 -type f -name "*.yaml" | sed "s|$2/*||g"); do
+            # shellcheck disable=SC2086
 			resources+=("$(tr -s '/' <<<$f)")
 		done
 
@@ -114,6 +115,7 @@ findres() {
 		done
 	else
 		r=$(echo "$1" | sed "s|$2/*||g")
+        # shellcheck disable=SC2086
 		resources+=("$(tr -s '/' <<<$r)")
 	fi
 }

--- a/tools/fake-flux-build
+++ b/tools/fake-flux-build
@@ -106,7 +106,7 @@ EOF
 findres() {
 	if ! [ -e "$1"/kustomization.yaml ]; then
 		for f in $(find "$1" -maxdepth 1 -type f -name "*.yaml" | sed "s|$2/*||g"); do
-            # shellcheck disable=SC2086
+			# shellcheck disable=SC2086
 			resources+=("$(tr -s '/' <<<$f)")
 		done
 
@@ -115,7 +115,7 @@ findres() {
 		done
 	else
 		r=$(echo "$1" | sed "s|$2/*||g")
-        # shellcheck disable=SC2086
+		# shellcheck disable=SC2086
 		resources+=("$(tr -s '/' <<<$r)")
 	fi
 }

--- a/tools/fake-flux-build
+++ b/tools/fake-flux-build
@@ -105,16 +105,16 @@ EOF
 
 findres() {
 	if ! [ -e "$1"/kustomization.yaml ]; then
-		for f in $(find "$1" -maxdepth 1 -type f -name "*.yaml" | sed "s|$2/||g"); do
-			resources+=("$f")
+		for f in $(find "$1" -maxdepth 1 -type f -name "*.yaml" | sed "s|$2/*||g"); do
+			resources+=("$(tr -s '/' <<< $f)")
 		done
 
 		for d in $(find "$1" -maxdepth 1 -type d ! -path "$1"); do
 			findres "$d" "$2"
 		done
 	else
-		r=$(echo "$1" | sed "s|$2/||g")
-		resources+=("$r")
+		r=$(echo "$1" | sed "s|$2/*||g")
+		resources+=("$(tr -s '/' <<< $r)")
 	fi
 }
 


### PR DESCRIPTION
> This PR requires testing on mac before merging

Occasionally `fake-flux-build` fails with the error

```
Error: accumulating resources: accumulation err='accumulating resources from 'management-clusters/MC/organizations/ORG/workload-clusters/WC/manifests/FILENAME.enc.yaml': 
evalsymlink failure on '/GITROOT/management-clusters/MC/organizations/ORG/workload-clusters/WC/management-clusters/MC/organizations/ORG/workload-clusters/WC/manifests/FILENAME.enc.yaml' :
lstat /GITROOT/management-clusters/MC/organizations/ORG/workload-clusters/WC/management-clusters: no such file or directory':
must build at directory: not a valid directory: 
evalsymlink failure on '/GITROOT/management-clusters/MC/organizations/ORG/workload-clusters/WC/management-clusters/MC/organizations/ORG/workload-clusters/WC/manifests/FILENAME.enc.yaml' :
lstat /GITROOT/management-clusters/MC/organizations/ORG/workload-clusters/WC/management-clusters: no such file or directory
```

This is caused by two sed commands in the `findres` function which replace `$2/`. The issue is the last `/` which may or may not be there depending on the system and needs to be made optional.

Secondly, I am not a fan of seeing `//` in path names, `tr -s` squashes these to `/`

Additional changes:
  - Added example of how to target resource(s) in a build with `yq`