### PR TITLE
Set all Kustomization templates to prune: false

### DIFF
--- a/docs/add_mc.md
+++ b/docs/add_mc.md
@@ -182,7 +182,7 @@ en- and decrypt real user-related data.
       namespace: default
     spec:
       serviceAccountName: automation
-      prune: true
+      prune: false
       interval: 1m
       path: "./management-clusters/${MC_NAME}"
       sourceRef:

--- a/docs/add_wc_environments.md
+++ b/docs/add_wc_environments.md
@@ -109,7 +109,7 @@ Change our working directory to the `hello_app_cluster` development cluster envi
 cd bases/environments/stages/dev/hello_app_cluster
 ```
 
-Let's crete the `kustomization.yaml` file for the development cluster.
+Let's create the `kustomization.yaml` file for the development cluster.
 
 ```sh
 cat <<EOF > kustomization.yaml
@@ -578,6 +578,22 @@ spec:
 
 EOF
 ```
+
+> **Note**
+>
+> In this example, we specifically set the `prune` value to `false`.
+>
+> This is to ensure that in the event of accidental deletion or modification of
+> the Kustomiation resource, clusters are not automatically deleted as part of
+> the cleanup action carried out by Flux.
+>
+> It is recommended, and considered good practice that this remains `false`
+> until such time that a cluster is specifically being deleted.
+>
+> In this instance, two commits should be made.
+>
+> 1. To explicitly set `prune: true` along with a commit message detailing why.
+> 1. To delete the Kustomization controlling this cluster.
 
 In our example we create one instance from each cluster environment base:
 

--- a/management-clusters/MC_NAME/MC_NAME.yaml
+++ b/management-clusters/MC_NAME/MC_NAME.yaml
@@ -10,7 +10,11 @@ spec:
       name: sops-gpg-master
   interval: 1m0s
   path: ./management-clusters/MC_NAME
-  prune: true
+  # Top level kustomizations may have prune set to `true`
+  # only if they do not handle cluster creation.
+  #
+  # Where cluster creation is being handled, this should default to false
+  prune: false
   serviceAccountName: automation
   sourceRef:
     kind: GitRepository

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP-direct.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP-direct.yaml
@@ -13,7 +13,7 @@ spec:
     substitute:
       cluster_name: "mapi-out-of-band-no-flux"
       organization: "org-name"
-  prune: true
+  prune: false
   sourceRef:
     kind: GitRepository
     name: your-repo  # TODO: change "your-repo" to the name of GitRepository pointing to your gitops repo for this cluster (might be the same or different than the one used for the MC)


### PR DESCRIPTION
- There have been multiple instances of customers using this template accidentally deleting workload clusters due to the flag `prune: true` being set on controlling `Kustomization` resources.

- This commit defaults all template prune settings to `false` and introduces a note in the `add_wc_environments.md` documentation to explain the reason it should be set to false.

- although the documented example was already false, there was no offered explanation around this value and this is driving confusion amongst adoptors of this template.