### PR TITLE
Fixes deprecated kubectl gs template app flags

### DIFF
--- a/docs/apps/add_app_template.md
+++ b/docs/apps/add_app_template.md
@@ -45,9 +45,9 @@ generate the [App CR](https://docs.giantswarm.io/ui-api/kubectl-gs/template-app/
     kubectl gs template app \
     --app-name ${APP_NAME} \
     --catalog ${APP_CATALOG} \
-    --cluster ${WC_NAME} \
+    --cluster-name ${WC_NAME} \
     --name ${APP_NAME} \
-    --namespace ${APP_NAMESPACE} \
+    --target-namespace ${APP_NAMESPACE} \
     --version {$APP_VERSION} > appcr.yaml
     ```
 

--- a/docs/apps/add_appcr.md
+++ b/docs/apps/add_appcr.md
@@ -70,9 +70,9 @@ generate the [App CR](https://docs.giantswarm.io/ui-api/kubectl-gs/template-app/
     kubectl gs template app \
     --app-name "\${cluster_name}-${APP_NAME}" \
     --catalog ${APP_CATALOG} \
-    --cluster ${WC_NAME} \
+    --cluster-name ${WC_NAME} \
     --name ${APP_NAME} \
-    --namespace ${APP_NAMESPACE} \
+    --target-namespace ${APP_NAMESPACE} \
     --version ${APP_VERSION} > appcr.yaml
     ```
 


### PR DESCRIPTION
In https://github.com/giantswarm/kubectl-gs/pull/886, for the `template app` command, we deprecated `--cluster` for `--cluster-name`, and `--namespace` for `--target-namespace`.

This PR updates the usage of those commands in the documentation so that kubectl gs does not print deprecating warnings anymore. 

I could not find any other usages of this command, or other deprecated commands, but they may exist.