### PR TITLE
docs: reflect LastPass to 1Password migration

### DIFF
--- a/docs/add_mc.md
+++ b/docs/add_mc.md
@@ -88,12 +88,14 @@ en- and decrypt real user-related data.
     --from-file=${MC_NAME}.master.asc=/dev/stdin
     ```
 
-1. Add the private to a safe encrypted storage of your choice. For example, to export the key to `LastPass`
+1. Add the private to a safe encrypted storage of your choice. For example, to export the key to 1Password
    as a secure note, you can run:
 
     ```sh
+    eval $(op signin)
     gpg --export-secret-keys --armor "${KEY_FP}" |
-    lpass add --notes --non-interactive "Shared-Dev Common/GPG private key (${MC_NAME}, master, Flux)"
+    jq -snR '{"fields": [{"value": inputs  }]}' |
+    op item create --vault 'Dev Common' --category securenote --title "GPG private key (${MC_NAME}, master, Flux)" --format json -
     ```
 
 1. Delete the private key from the keychain (make sure you don't leave any unencrypted or local copies of the private

--- a/docs/add_org.md
+++ b/docs/add_org.md
@@ -142,11 +142,12 @@ new GPG key-pair dedicated for an organization.
     ```
 
 1. Import the management cluster's master GPG private key from your safe storage into your keychain. In our example, we're
-going to use `LastPass` for that:
+going to use 1Password (`op` CLI tool) for that:
 
     ```sh
+    eval $(op signin)
     gpg --import \
-    <(lpass show --notes "Shared-Dev Common/GPG private key (${MC_NAME}, master, Flux)")
+    <(op item get --vault 'Dev Common' "GPG private key (${MC_NAME}, master, Flux)" --reveal --fields notesPlain)
     ```
 
 1. Decrypt the `${MC_NAME}.gpgkey.enc.yaml` file with SOPS:

--- a/docs/add_org.md
+++ b/docs/add_org.md
@@ -147,7 +147,7 @@ going to use 1Password (`op` CLI tool) for that:
     ```sh
     eval $(op signin)
     gpg --import \
-    <(op item get --vault 'Dev Common' "GPG private key (${MC_NAME}, master, Flux)" --reveal --fields notesPlain)
+    <(op read "Dev Common/GPG private key (${MC_NAME}, master, Flux)/notesPlain")
     ```
 
 1. Decrypt the `${MC_NAME}.gpgkey.enc.yaml` file with SOPS:

--- a/docs/add_wc_structure.md
+++ b/docs/add_wc_structure.md
@@ -114,11 +114,13 @@ Kubernetes Secret, you MUST not create multiple Secrets.
     ```
 
 1. As a backup, save the private key to an external encrypted storage. As an example, you can add the private key
-   to LastPass as a secure note:
+   to 1Password (`op` CLI tool) as a secure note:
 
     ```sh
+    eval $(op signin)
     gpg --export-secret-keys --armor "${KEY_FP}" |
-    lpass add --notes --non-interactive "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)"
+    jq -snR '{"fields": [{"value": inputs }]}' |
+    op item create --vault 'Dev Common' --category securenote --title "GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --format json -
     ```
 
 1. Delete the private key from the keychain:

--- a/docs/apps/update_appcr.md
+++ b/docs/apps/update_appcr.md
@@ -57,11 +57,12 @@ fields reference [the App CRD schema](https://docs.giantswarm.io/ui-api/manageme
     ```
 
 1. Import the WC's regular GPG private key from your safe storage into your keychain. In our example, we're gonna
-   use `LastPass` for that:
+   use 1Password's CLI `op` for that:
 
     ```sh
+    eval $(op signin)
     gpg --import \
-    <(lpass show --notes "Shared-Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)")
+    <(op item get --vault 'Dev Common' "GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
     ```
 
 1. Decrypt the `secret.enc.yaml` file with SOPS:

--- a/docs/apps/update_appcr.md
+++ b/docs/apps/update_appcr.md
@@ -62,7 +62,7 @@ fields reference [the App CRD schema](https://docs.giantswarm.io/ui-api/manageme
     ```sh
     eval $(op signin)
     gpg --import \
-    <(op item get --vault 'Dev Common' "GPG private key (${MC_NAME}, ${WC_NAME}, Flux)" --reveal --fields notesPlain)
+    <(op read "Dev Common/GPG private key (${MC_NAME}, ${WC_NAME}, Flux)/notesPlain")
     ```
 
 1. Decrypt the `secret.enc.yaml` file with SOPS:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32651

### Summary

Migrate to using 1Password as secret store in documentation.

The `op` commands were tested and should work. The `jq` tool seems to be a requirement to safely craft "secure note" secrets, for creation using 1Password's `op` CLI.
