### PR TITLE
Add semantic YAML diff PR comments via shared workflow

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   kubeconform_ver: "0.4.13"
-  dyff_ver: "1.5.4"
+  dyff_ver: "1.7.1"
   clusterctl_ver: "1.2.0"
   apptestctl_ver: "0.18.0"
   kind_ver: "0.12.0"

--- a/.github/workflows/yaml-diff.yaml
+++ b/.github/workflows/yaml-diff.yaml
@@ -1,0 +1,12 @@
+name: yaml-diff
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  yaml-diff:
+    uses: giantswarm/github-workflows/.github/workflows/yaml-diff.yaml@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Semantic YAML diff PR comments via the new `yaml-diff` workflow (calls `giantswarm/github-workflows/.github/workflows/yaml-diff.yaml`). Key reordering without value changes no longer shows up as noise in PR reviews. Alphabetical key-ordering enforcement in `.yamllint` is unchanged in this release; it will be dropped in a follow-up once the bot has run on real PRs. See [giantswarm/roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121).
+- Semantic YAML diff PR comments via the new `yaml-diff` workflow
+  (calls `giantswarm/github-workflows/.github/workflows/yaml-diff.yaml`).
+  Key reordering without value changes no longer shows up as noise in PR
+  reviews. Alphabetical key-ordering enforcement in `.yamllint` is
+  unchanged in this release; it will be dropped in a follow-up once the
+  bot has run on real PRs.
+  See [giantswarm/roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121).
 
 ### Changed
 
-- Bump `dyff_ver` from `1.5.4` to `1.7.1` in the existing rendered-manifest diff job (`validate.yaml`), to standardize on the version used by the new `yaml-diff` workflow.
+- Bump `dyff_ver` from `1.5.4` to `1.7.1` in the existing rendered-manifest
+  diff job (`validate.yaml`), to standardize on the version used by the new
+  `yaml-diff` workflow.
 - migrated `.spec.config` to `.spec.extraConfigs`
 - Templates: Rename `nginx-ingress-controller` to `ingress-nginx`. ([#85](https://github.com/giantswarm/gitops-template/pull/85))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Semantic YAML diff PR comments via the new `yaml-diff` workflow (calls `giantswarm/github-workflows/.github/workflows/yaml-diff.yaml`). Key reordering without value changes no longer shows up as noise in PR reviews. Alphabetical key-ordering enforcement in `.yamllint` is unchanged in this release; it will be dropped in a follow-up once the bot has run on real PRs. See [giantswarm/roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121).
+
 ### Changed
 
+- Bump `dyff_ver` from `1.5.4` to `1.7.1` in the existing rendered-manifest diff job (`validate.yaml`), to standardize on the version used by the new `yaml-diff` workflow.
 - migrated `.spec.config` to `.spec.extraConfigs`
 - Templates: Rename `nginx-ingress-controller` to `ingress-nginx`. ([#85](https://github.com/giantswarm/gitops-template/pull/85))
 


### PR DESCRIPTION
## Summary

Adopts the new [`giantswarm/github-workflows/.github/workflows/yaml-diff.yaml`](https://github.com/giantswarm/github-workflows/pull/190) reusable workflow. On every PR, a bot now posts a **semantic** YAML diff (via `dyff`) of changed source files as a sticky comment, ignoring key reordering.

This is **additive infrastructure** for [giantswarm/roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121). No existing CI behaviour changes:

- `key-ordering: {}` in `.yamllint` **stays** in this PR. yamllint continues to enforce alphabetical key ordering as before.
- The bot just adds a clean semantic-diff comment alongside.

Once the bot has run on real PRs and proves stable (~1–2 weeks), a separate small PR will drop `key-ordering: {}` from `.yamllint`, closing #4121.

## Changes

- **New** `.github/workflows/yaml-diff.yaml` — thin caller; declares its own `pull-requests: write` + `contents: read` permissions (a reusable workflow can only narrow, not grant).
- **`.github/workflows/validate.yaml`** — bump `dyff_ver` from `1.5.4` to `1.7.1` to match the shared workflow.
- **CHANGELOG.md** — entries under Unreleased.

## Dependency

Depends on https://github.com/giantswarm/github-workflows/pull/190 being merged. The caller references `@main`, matching the convention used by other gitops-template reusable callers.

## Test plan

- [ ] After merging giantswarm/github-workflows#190, this PR's own CI should post a YAML-diff comment (nothing semantic to diff in this PR though).
- [ ] Follow-up: open a test PR with a key-reorder-only change → expect `yamllint` to still fail (rule still in place) **and** bot to post "No semantic YAML differences" — proves the bot can detect the no-op even with the rule active.
- [ ] Follow-up: open a test PR with a value change → bot posts only the value diff.
- [ ] Follow-up: `/no_diffs_printing` in PR body → bot skips posting.
- [ ] Confirm the existing rendered-Helm-diff `get-diff` job still works after the `dyff_ver` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)