### PR TITLE
chore: replace decommissioned giantswarmpublic.azurecr.io registry

### DIFF
--- a/bases/environments/stages/dev/hello_app_cluster/automatic_updates/catalog.yaml
+++ b/bases/environments/stages/dev/hello_app_cluster/automatic_updates/catalog.yaml
@@ -9,9 +9,9 @@ spec:
   description: giantswarm-catalog-oci
   logoURL: "https://avatars.githubusercontent.com/u/7556340?s=60&v=4"
   repositories:
-    - URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    - URL: oci://gsoci.azurecr.io/charts/giantswarm/
       type: helm
   storage:
-    URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   title: giantswarm-catalog-oci

--- a/bases/environments/stages/dev/hello_app_cluster/imagerepositories.yaml
+++ b/bases/environments/stages/dev/hello_app_cluster/imagerepositories.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ${cluster_name}-hello-app
   namespace: org-${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 10m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2

--- a/bases/environments/stages/staging/hello_app_cluster/automatic_updates/catalog.yaml
+++ b/bases/environments/stages/staging/hello_app_cluster/automatic_updates/catalog.yaml
@@ -9,9 +9,9 @@ spec:
   description: giantswarm-catalog-oci
   logoURL: "https://avatars.githubusercontent.com/u/7556340?s=60&v=4"
   repositories:
-    - URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    - URL: oci://gsoci.azurecr.io/charts/giantswarm/
       type: helm
   storage:
-    URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   title: giantswarm-catalog-oci

--- a/bases/environments/stages/staging/hello_app_cluster/imagerepositories.yaml
+++ b/bases/environments/stages/staging/hello_app_cluster/imagerepositories.yaml
@@ -5,7 +5,7 @@ metadata:
   name: ${cluster_name}-hello-app
   namespace: org-${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 10m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2

--- a/docs/add_wc_environments.md
+++ b/docs/add_wc_environments.md
@@ -176,7 +176,7 @@ spec:
   description: giantswarm-catalog-oci
   logoURL: "https://avatars.githubusercontent.com/u/7556340?s=60&v=4"
   storage:
-    URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   title: giantswarm-catalog-oci
 EOF
@@ -223,7 +223,7 @@ where to look for updates stored in: [imagerepositories.yaml](
 /bases/environments/stages/dev/hello_app_cluster/imagerepositories.yaml).
 
 Let's tell Flux to look for available images for the `hello-world-app`
-in the `giantswarmpublic.azurecr.io/giantswarm-catalog` registry every 10 minutes.
+in the `gsoci.azurecr.io/charts/giantswarm` registry every 10 minutes.
 
 ```sh
 cat <<EOF > imagerepositories.yaml
@@ -234,7 +234,7 @@ metadata:
   name: \${cluster_name}-hello-app
   namespace: org-\${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 10m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/hello-world-automatic-updates/imagerepository.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/hello-world-automatic-updates/imagerepository.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ${cluster_name}-hello-world
   namespace: org-${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 30m0s

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/automatic-updates/catalog.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/automatic-updates/catalog.yaml
@@ -12,6 +12,6 @@ spec:
     - URL: https://giantswarm.github.io/giantswarm-catalog/
       type: helm
   storage:
-    URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   title: giantswarm-catalog-oci

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/apps/hello-world-automatic-updates/imagerepository.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/apps/hello-world-automatic-updates/imagerepository.yaml
@@ -4,5 +4,5 @@ metadata:
   name: ${cluster_name}-hello-world
   namespace: org-${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 30m0s

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/automatic-updates/catalog.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_NO_FLUX_APP/mapi/automatic-updates/catalog.yaml
@@ -12,6 +12,6 @@ spec:
     - URL: https://giantswarm.github.io/giantswarm-catalog/
       type: helm
   storage:
-    URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   title: giantswarm-catalog-oci

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/catalogs.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/catalogs.yaml
@@ -7,9 +7,9 @@ spec:
   description: giantswarm-catalog-oci
   logoURL: https://avatars.githubusercontent.com/u/7556340?s=60&v=4
   repositories:
-  - URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+  - URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   storage:
-    URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   title: giantswarm-catalog-oci

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/imagerepositories.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/imagerepositories.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hello-app-dev-1-hello-app
   namespace: org-org-name
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 10m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/catalogs.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/catalogs.yaml
@@ -7,9 +7,9 @@ spec:
   description: giantswarm-catalog-oci
   logoURL: https://avatars.githubusercontent.com/u/7556340?s=60&v=4
   repositories:
-  - URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+  - URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   storage:
-    URL: oci://giantswarmpublic.azurecr.io/giantswarm-catalog/
+    URL: oci://gsoci.azurecr.io/charts/giantswarm/
     type: helm
   title: giantswarm-catalog-oci

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/imagerepositories.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/imagerepositories.yaml
@@ -5,7 +5,7 @@ metadata:
   name: hello-app-staging-1-hello-app
   namespace: org-org-name
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app
+  image: gsoci.azurecr.io/charts/giantswarm/hello-world
   interval: 10m0s
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2


### PR DESCRIPTION
## What

The `giantswarmpublic.azurecr.io` registry, which hosted Giant Swarm Helm chart catalogs, has been decommissioned. All chart catalogs are now consolidated onto `oci://gsoci.azurecr.io/charts/giantswarm/`.

This PR replaces all references accordingly:

- `oci://giantswarmpublic.azurecr.io/giantswarm-catalog/` → `oci://gsoci.azurecr.io/charts/giantswarm/`
- `giantswarmpublic.azurecr.io/giantswarm-catalog/hello-world-app` → `gsoci.azurecr.io/charts/giantswarm/hello-world` (the demo app's chart is named `hello-world` on the new registry; the path also changes, not just the domain)
- Bare `giantswarmpublic.azurecr.io/giantswarm-catalog` (e.g. prose in docs) → `gsoci.azurecr.io/charts/giantswarm`

## Files changed

- `docs/add_wc_environments.md`
- `bases/environments/stages/{dev,staging}/hello_app_cluster/imagerepositories.yaml`
- `bases/environments/stages/{dev,staging}/hello_app_cluster/automatic_updates/catalog.yaml`
- `management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_{FLUX,NO_FLUX}_APP/mapi/apps/hello-world-automatic-updates/imagerepository.yaml`
- `management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_{FLUX,NO_FLUX}_APP/mapi/automatic-updates/catalog.yaml`
- `tests/ats/assertions/exists/organizations/workload-clusters/hello-app-{dev,staging}-1/catalogs.yaml`
- `tests/ats/assertions/exists/organizations/workload-clusters/hello-app-{dev,staging}-1/imagerepositories.yaml`

## Intentionally left untouched: `simple-db-app`

The `simple-db-app` chart no longer exists and is **not** available on `gsoci`. All lines referencing `simple-db-app` are deliberately left pointing at the old `giantswarmpublic.azurecr.io` registry and are **not** modified in this PR. Replacing the `simple-db-app` demo is tracked separately in #131.
