### PR TITLE
[TEST] yaml-diff: key reorder only (no value change)

### DIFF
--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
@@ -1,4 +1,8 @@
+kind: ConfigMap
 apiVersion: v1
+metadata:
+  name: secret-to-be-created-directly-in-WC
+  namespace: default
 data:
   values: |-
     Test ConfigMap.
@@ -6,7 +10,3 @@ data:
     I am the ${cluster_name} cluster!
     I belong to the ${organization} org!
     Encryption is possible here as well, but I am not encrypted atm.
-kind: ConfigMap
-metadata:
-  name: secret-to-be-created-directly-in-WC
-  namespace: default


### PR DESCRIPTION
**Throwaway test PR** for the yaml-diff bot rollout — [roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121). Do not merge; close after verifying.

## What this tests

Top-level keys of one ConfigMap are reordered (`kind`/`apiVersion`/`metadata`/`data`), **no values changed**.

## Expected

- ✅ `yaml-diff` bot comment: **"No semantic YAML differences"** (dyff `--ignore-order-changes`).
- ❌ `validate` / yamllint **fails** `key-ordering` — this is expected and is exactly the friction #4121 is about. It demonstrates the bot correctly sees a no-op while the lint rule still rejects the reorder, which is the case for dropping `key-ordering: {}` in phase 2.
