### PR TITLE
[TEST] yaml-diff: real value change

### DIFF
--- a/.github/workflows/yaml-diff.yaml
+++ b/.github/workflows/yaml-diff.yaml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   yaml-diff:
-    uses: giantswarm/github-workflows/.github/workflows/yaml-diff.yaml@main
+    uses: giantswarm/github-workflows/.github/workflows/yaml-diff.yaml@feat/yaml-diff-color

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
@@ -5,8 +5,8 @@ data:
     Variable substitution still possible here.
     I am the ${cluster_name} cluster!
     I belong to the ${organization} org!
-    Encryption is possible here as well, but I am not encrypted atm.
+    Encryption is possible here as well, but I am not encrypted yet.
 kind: ConfigMap
 metadata:
   name: secret-to-be-created-directly-in-WC
-  namespace: kube-system
+  namespace: default

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
@@ -9,4 +9,4 @@ data:
 kind: ConfigMap
 metadata:
   name: secret-to-be-created-directly-in-WC
-  namespace: default
+  namespace: kube-system


### PR DESCRIPTION
**Throwaway test PR** for the yaml-diff bot rollout — [roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121). Do not merge; close after verifying.

## What this tests

One ConfigMap value changed (`metadata.namespace: default` → `kube-system`), key order preserved.

## Expected

- ✅ `yaml-diff` bot comment showing **only** the namespace value change.
- ✅ `validate` / yamllint passes (alphabetical order preserved).
