### PR TITLE
[TEST] yaml-diff: opt-out via /no_diffs_printing

### DIFF
--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
@@ -5,8 +5,8 @@ data:
     Variable substitution still possible here.
     I am the ${cluster_name} cluster!
     I belong to the ${organization} org!
-    Encryption is possible here as well, but I am not encrypted atm.
+    Encryption is possible here as well, but I am opted out of diffs.
 kind: ConfigMap
 metadata:
   name: secret-to-be-created-directly-in-WC
-  namespace: monitoring
+  namespace: default

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
@@ -9,4 +9,4 @@ data:
 kind: ConfigMap
 metadata:
   name: secret-to-be-created-directly-in-WC
-  namespace: default
+  namespace: monitoring


### PR DESCRIPTION
**Throwaway test PR** for the yaml-diff bot rollout — [roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121). Do not merge; close after verifying.

## What this tests

A real value change (`metadata.namespace: default` → `monitoring`) **plus** the opt-out command below. The `check-cmp-state` job greps the PR body for it and should skip the diff job.

/no_diffs_printing

## Expected

- ✅ **No** `yaml-diff` bot comment (job skipped despite a real value change).
- ✅ `validate` / yamllint passes.
