### PR TITLE
[TEST] yaml-diff: SOPS *.enc.yaml excluded

### DIFF
--- a/.github/workflows/yaml-diff.yaml
+++ b/.github/workflows/yaml-diff.yaml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   yaml-diff:
-    uses: giantswarm/github-workflows/.github/workflows/yaml-diff.yaml@main
+    uses: giantswarm/github-workflows/.github/workflows/yaml-diff.yaml@fix/yaml-diff-enc-exclusion

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/ingress-nginx-from-template/secret.enc.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/mapi/apps/ingress-nginx-from-template/secret.enc.yaml
@@ -11,7 +11,7 @@ sops:
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2022-08-10T12:18:52Z'
+    lastmodified: '2026-06-30T14:40:00Z'
     mac: ENC[AES256_GCM,data:MlelYpvTgNDJ51+lruKpE5WZsQIJ2Tg66suRu4Cio5RK4JSjrsY/LQLv+HtbhzGKCjWkdw/Or2nfOeRCbrj0KQhKKrFiSRi7wR2+mNolvRbZ5dnsnbNSx5rGetnxearGyuSpMt35rFybI9RnnI878Sg8D1mjzrtmIn2hb8V37do=,iv:TiMKmgwf6GIqwS8Gv//lauhHx0FaL0BcFW06un50dwQ=,tag:gW1UW1+HfbhfOUoKSzVhtA==,type:str]
     pgp:
     -   created_at: '2022-08-10T12:18:52Z'

--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
@@ -5,7 +5,7 @@ data:
     Variable substitution still possible here.
     I am the ${cluster_name} cluster!
     I belong to the ${organization} org!
-    Encryption is possible here as well, but I am not encrypted atm.
+    Encryption is possible here as well, but I am not encrypted yet.
 kind: ConfigMap
 metadata:
   name: secret-to-be-created-directly-in-WC


### PR DESCRIPTION
**Throwaway test PR** for the yaml-diff bot rollout — [roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121). Do not merge; close after verifying.

## What this tests

Two files change in one PR:
1. A real ConfigMap value change (`data.values`).
2. A SOPS-encrypted `secret.enc.yaml` (touched `sops.lastmodified`).

## Expected

- ✅ `yaml-diff` bot comment shows **only** the ConfigMap diff.
- ✅ The `*.enc.yaml` is **not** mentioned (matched by the default `**/*.enc.yaml` exclude). SOPS files must never be diffed.
