### PR TITLE
[TEST] yaml-diff: newly added file

### DIFF
--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/added-test-configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/added-test-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  note: |-
+    Brand-new file added to exercise the yaml-diff bot's "added file" path.
+kind: ConfigMap
+metadata:
+  name: yaml-diff-added-file-test
+  namespace: default


### PR DESCRIPTION
**Throwaway test PR** for the yaml-diff bot rollout — [roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121). Do not merge; close after verifying.

## What this tests

A brand-new YAML file is added (git status `A`). There's no base content to diff against.

## Expected

- ✅ `yaml-diff` bot comment lists the new file path with **`(Added — see file diff in PR for content)`** rather than a dyff (dyff-against-/dev/null is intentionally avoided).
