### PR TITLE
Drop key-ordering enforcement from .yamllint

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,7 +3,6 @@ ignore: |
   *.enc.yaml
   .github/**
   .pre-commit-config.yaml
-rules:
-  key-ordering: {}
+rules: {}
 yaml-files:
   - "*.yaml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - migrated `.spec.config` to `.spec.extraConfigs`
 - Templates: Rename `nginx-ingress-controller` to `ingress-nginx`. ([#85](https://github.com/giantswarm/gitops-template/pull/85))
 
+### Removed
+
+- Dropped the alphabetical `key-ordering` rule from `.yamllint`. It only
+  existed to keep PR diffs readable; the `yaml-diff` bot now provides clean
+  semantic diffs (ignoring key reordering), so the restriction is no longer
+  needed. Closes
+  [giantswarm/roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121).
+
 ## [0.1.0] Initial release
 
 - Added


### PR DESCRIPTION
## Summary

**Phase 2** of [giantswarm/roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121) — removes the alphabetical `key-ordering` rule from `.yamllint`.

That rule only ever existed to keep PR diffs readable, at the cost of forcing an unnatural key order on Kubernetes resources. Now that the **`yaml-diff` bot** posts clean semantic diffs on every PR (ignoring key reordering, verified over Phase 1), the restriction is no longer needed.

```diff
 rules:
-  key-ordering: {}
+rules: {}
```

`key-ordering` was the only rule this config enabled, so yamllint now enforces nothing (SOPS/`.github`/pre-commit ignores unchanged). This is a one-line revert if anything surprises us.

Closes #4121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)