### PR TITLE
[TEST] yaml-diff colour output demo

### DIFF
--- a/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
+++ b/management-clusters/MC_NAME/organizations/ORG_NAME/workload-clusters/WC_NAME_OUT_OF_BAND_FLUX_APP/out-of-band/configmaps/configmap.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 data:
   values: |-
-    Test ConfigMap.
+    Test ConfigMap (colour demo).
     Variable substitution still possible here.
     I am the ${cluster_name} cluster!
     I belong to the ${organization} org!
-    Encryption is possible here as well, but I am not encrypted atm.
+    Encryption is possible here as well, but I am not encrypted yet.
 kind: ConfigMap
 metadata:
   name: secret-to-be-created-directly-in-WC


### PR DESCRIPTION
**Throwaway demo PR** for [roadmap#4121](https://github.com/giantswarm/roadmap/issues/4121) — to view the **colourised** `yaml-diff` bot comment now that github-workflows#232 is on `@main`.

Changes two lines of a ConfigMap's `data.values`. Expect the bot to post a ` ```diff ` block where the removed lines render **red**, the added lines **green**, and the file header (`@@ … @@`) stands out. Close after eyeballing.