### PR TITLE
fix: point example simple-db-app ImageRepository at gsoci registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `yaml-diff` workflow.
 - migrated `.spec.config` to `.spec.extraConfigs`
 - Templates: Rename `nginx-ingress-controller` to `ingress-nginx`. ([#85](https://github.com/giantswarm/gitops-template/pull/85))
+- Example `simple-db-app` `ImageRepository` now points at the current registry
+  `gsoci.azurecr.io/charts/giantswarm/simple-db-app` instead of the
+  decommissioned `giantswarmpublic.azurecr.io/giantswarm-catalog/simple-db-app`
+  (bases, `add_wc_environments.md` docs, and `tests/ats` fixtures), matching the
+  sibling `hello-world` example. See
+  [giantswarm/giantswarm#35783](https://github.com/giantswarm/giantswarm/issues/35783).
 
 ### Removed
 

--- a/bases/environments/stages/dev/hello_app_cluster/imagerepositories.yaml
+++ b/bases/environments/stages/dev/hello_app_cluster/imagerepositories.yaml
@@ -14,5 +14,5 @@ metadata:
   name: ${cluster_name}-simple-db-app
   namespace: org-${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/simple-db-app
+  image: gsoci.azurecr.io/charts/giantswarm/simple-db-app
   interval: 10m0s

--- a/bases/environments/stages/staging/hello_app_cluster/imagerepositories.yaml
+++ b/bases/environments/stages/staging/hello_app_cluster/imagerepositories.yaml
@@ -14,5 +14,5 @@ metadata:
   name: ${cluster_name}-simple-db-app
   namespace: org-${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/simple-db-app
+  image: gsoci.azurecr.io/charts/giantswarm/simple-db-app
   interval: 10m0s

--- a/docs/add_wc_environments.md
+++ b/docs/add_wc_environments.md
@@ -243,7 +243,7 @@ metadata:
   name: \${cluster_name}-simple-db-app
   namespace: org-\${organization}
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/simple-db-app
+  image: gsoci.azurecr.io/charts/giantswarm/simple-db-app
   interval: 10m0s
 EOF
 ```

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/imagerepositories.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/imagerepositories.yaml
@@ -14,5 +14,5 @@ metadata:
   name: hello-app-dev-1-simple-db-app
   namespace: org-org-name
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/simple-db-app
+  image: gsoci.azurecr.io/charts/giantswarm/simple-db-app
   interval: 10m0s

--- a/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/imagerepositories.yaml
+++ b/tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/imagerepositories.yaml
@@ -14,5 +14,5 @@ metadata:
   name: hello-app-staging-1-simple-db-app
   namespace: org-org-name
 spec:
-  image: giantswarmpublic.azurecr.io/giantswarm-catalog/simple-db-app
+  image: gsoci.azurecr.io/charts/giantswarm/simple-db-app
   interval: 10m0s


### PR DESCRIPTION
## What

The example `simple-db-app` `ImageRepository` referenced the **decommissioned** `giantswarmpublic.azurecr.io/giantswarm-catalog/simple-db-app` registry. This updates it to the current `gsoci.azurecr.io/charts/giantswarm/simple-db-app`, consistent with the sibling `hello-world` example in the same template and with the app's `catalog: giantswarm` (which lives at `gsoci.azurecr.io/charts/giantswarm/`).

Files changed (all 5 occurrences):
- `bases/environments/stages/dev/hello_app_cluster/imagerepositories.yaml`
- `bases/environments/stages/staging/hello_app_cluster/imagerepositories.yaml`
- `tests/ats/assertions/exists/organizations/workload-clusters/hello-app-dev-1/imagerepositories.yaml`
- `tests/ats/assertions/exists/organizations/workload-clusters/hello-app-staging-1/imagerepositories.yaml`
- `docs/add_wc_environments.md`

## Why

`giantswarmpublic.azurecr.io` is decommissioned, so a Flux `ImageRepository` pointing at it silently fails to scan tags. Fixing the template stops new clusters from copying the stale registry.

Part of giantswarm/giantswarm#35783.

## Notes

- `simple-db-app` is fictional tutorial-only content (not published to any registry), so this aligns the **registry name** with the rest of the template; it does not make the example resolve a real chart (pre-existing, out of scope).
- base + matching `tests/ats` exists-assertion fixture are updated together so the ATS e2e stays green.