### PR TITLE
feat: define and document repository structure version 1

### DIFF
--- a/.gitops-metadata.yaml
+++ b/.gitops-metadata.yaml
@@ -1,0 +1,15 @@
+---
+# Pins this repository, and anything forked from it, to a version of the
+# repository structure described in docs/repo_structure.md.
+#
+# `kubectl gs gitops` maintains this file: `gitops init` creates it and every
+# `gitops add ...` records the layer it generated under `layers`. It is listed
+# empty here because the trees under `management-clusters/` and `bases/` in
+# this repository are examples rather than generated layers. In a fork, run
+# `kubectl gs gitops check --adopt` once to record what is actually there, and
+# `kubectl gs gitops check` afterwards to find out when the fork has fallen
+# behind this structure.
+apiVersion: gitops.giantswarm.io/v1alpha1
+kind: RepositoryMetadata
+structureVersion: 1
+layers: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ following [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- The repository structure is now versioned. The layout described in
+  `docs/repo_structure.md` is **structure version 1**, and a new
+  [Structure Version](docs/repo_structure.md#structure-version) section
+  defines what does and does not warrant a bump. `kubectl gs gitops` records
+  the version in a `.gitops-metadata.yaml` file at the root of the
+  repositories it generates, and `kubectl gs gitops check` reports the parts
+  of a repository that were generated with an older one.
+  Bumping the version here requires bumping `StructureVersion` in
+  `kubectl-gs` to match; the two are kept in lockstep by hand.
+  See [giantswarm/giantswarm#23540](https://github.com/giantswarm/giantswarm/issues/23540).
 - Semantic YAML diff PR comments via the new `yaml-diff` workflow
   (calls `giantswarm/github-workflows/.github/workflows/yaml-diff.yaml`).
   Key reordering without value changes no longer shows up as noise in PR

--- a/docs/repo_structure.md
+++ b/docs/repo_structure.md
@@ -1,6 +1,7 @@
 # Repository Structure
 
 - [General Remarks](#general-remarks)
+- [Structure Version](#structure-version)
 - [Security Architecture](#security-architecture)
   - [Overview](#overview)
   - [Multiple GPG Keys](#multiple-gpg-keys)
@@ -75,6 +76,51 @@ see the [Flux Kustomization CRs Involved](#flux-kustomization-crs-involved).
 
 The security of resources is provided by GPG encryption. The repository provides a way to manage
 all the encryption and decryption keys through its structure, see the [Security Architecture](#security-architecture).
+
+## Structure Version
+
+The structure described in this document is versioned, so that a repository built on it can tell when it
+has fallen behind. **The current structure version is `1`.**
+
+The version is a plain integer, incremented whenever this document prescribes a change that an existing
+repository would have to follow: a directory that moves, a file that is added to every layer, a naming rule
+that changes. Purely additive documentation, new examples, and changes to the contents of the app manifests
+under `bases/` do not bump it.
+
+`kubectl gs gitops` records the version in a `.gitops-metadata.yaml` file at the root of the repository it
+generates, together with an entry for every management cluster, organization, workload cluster, app and
+cluster base it created:
+
+```yaml
+apiVersion: gitops.giantswarm.io/v1alpha1
+kind: RepositoryMetadata
+structureVersion: 1
+generatedWith: kubectl-gs/5.7.3
+layers:
+  - kind: management-cluster
+    path: management-clusters/MC_NAME
+    structureVersion: 1
+    generatedWith: kubectl-gs/5.7.3
+```
+
+That file is deliberately at the repository root, outside the scope the `MC_NAME.yaml` Kustomization CR
+reconciles, so it is never applied to a cluster. It is managed by the tooling and SHOULD NOT be edited
+by hand.
+
+Run `kubectl gs gitops check` against a clone to see which parts of it were generated with an older
+structure version. The command exits non-zero when anything is behind, so it can be wired into the
+repository's own CI. A repository created before the metadata file existed holds none; run
+`kubectl gs gitops check --adopt` once to record what is already there. Note that adoption assumes the
+existing layers are current, so it cannot recover drift from before it ran.
+
+The `check` command requires a `kubectl-gs` release that ships it; older versions have no
+`gitops check` subcommand. Run `kubectl gs gitops check --help` to confirm yours does, and
+`kubectl gs selfupdate` if it does not.
+
+When bumping the version, record what changed under the corresponding entry in this repository's
+[CHANGELOG](../CHANGELOG.md), and bump `StructureVersion` in
+[kubectl-gs](https://github.com/giantswarm/kubectl-gs/blob/main/internal/gitops/metadata/types.go) to match.
+The two are kept in lockstep by hand; nothing enforces it.
 
 ## Security Architecture
 


### PR DESCRIPTION
### What does this PR do?

Declares the layout this repository prescribes as **structure version 1**, and adds a
[Structure Version](https://github.com/giantswarm/gitops-template/blob/structure-version-23540/docs/repo_structure.md#structure-version)
section to `docs/repo_structure.md` defining what does and does not warrant a bump.

Also ships a `.gitops-metadata.yaml` at the repository root so that forks start pinned at version 1.

### Why

The structure had no version. A fork carried no marker of which generation of the layout it was
built from, so there was no way to tell it had fallen behind — and no way to enumerate what would
need updating. This repository has exactly one tag (`v0.1.0`, September 2022), zero published
releases, and every structural change since sits in a single `## Unreleased` CHANGELOG section.

### Companion PR

Pairs with **giantswarm/kubectl-gs#2081**, which teaches `kubectl gs gitops` to record the
version in the repositories it generates and adds `kubectl gs gitops check` to report drift.
Neither PR breaks without the other, but the docs here describe a command that only exists once
the kubectl-gs side is released — the new section says so explicitly.

### Why `layers: []` in the shipped file

The trees under `management-clusters/` and `bases/` here are *examples*, not generated layers.
Listing them would create an inventory that rots every time an example is added. A fork records
its real layers with `kubectl gs gitops check --adopt`. Staleness is harmless either way: `check`
compares versions, never completeness.

### What is being committed to

Shipping `structureVersion: 1` obliges someone to bump it when the layout changes, and to say what
changed. **Nothing enforces the lockstep** between the number here and `StructureVersion` in
`kubectl-gs/internal/gitops/metadata/types.go` — it is a convention, documented in both repos. If
reviewers want that enforced by CI rather than by discipline, say so and I will add it.

### What this does not do

This is the *detection* half of giantswarm/giantswarm#23540. Migration and upgrade tooling is
untouched — the part described in
[March 2025](https://github.com/giantswarm/giantswarm/issues/23540#issuecomment-2710779182) as an
open product feature. The issue stays open.

### What is needed from the reviewers

1. Agreement that version `1` is the right starting point, i.e. that today's `main` is the baseline.
2. A sanity check on the bump criteria in the new section.
3. Whether a root-level `.gitops-metadata.yaml` in every fork is acceptable.

### Verification

The new root file is invisible to every PR check: `tools/test-all-ff` filters `find` output by
`api.*\.fluxcd\.io` and this file does not match; `tests/ats/conftest.py` only applies
`management-clusters/<dir>/<dir>.yaml`; the only top-level Flux Kustomization has
`path: ./management-clusters/MC_NAME`. `yamllint` passes and no added markdown line exceeds
MD013's 120 characters.

Related: giantswarm/giantswarm#23540
